### PR TITLE
Fix glow lichen orientation

### DIFF
--- a/DimDatapack v4/data/dd/worldgen/configured_feature/glow_lichen_patch.json
+++ b/DimDatapack v4/data/dd/worldgen/configured_feature/glow_lichen_patch.json
@@ -12,7 +12,12 @@
             "state": {
               "Name": "minecraft:glow_lichen",
               "Properties": {
-                "north": "true"
+                "north": "true",
+                "south": "true",
+                "east": "true",
+                "west": "true",
+                "up": "true",
+                "down": "true"
               }
             }
           }
@@ -28,5 +33,4 @@
           }
         }
       ]
-    }
-  }}
+    }  }}


### PR DESCRIPTION
## Summary
- allow glow lichen to attach on every side of a block

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686e7eb0c084832ab586f79545a9a741