### PR TITLE
Fix glow lichen orientation

### DIFF
--- a/DimDatapack v4/data/dd/worldgen/configured_feature/glow_lichen_patch.json
+++ b/DimDatapack v4/data/dd/worldgen/configured_feature/glow_lichen_patch.json
@@ -10,12 +10,7 @@
           "to_place": {
             "type": "minecraft:weighted_state_provider",
             "entries": [
-              {"weight": 1, "data": {"Name": "minecraft:glow_lichen", "Properties": {"north": "true"}}},
-              {"weight": 1, "data": {"Name": "minecraft:glow_lichen", "Properties": {"south": "true"}}},
-              {"weight": 1, "data": {"Name": "minecraft:glow_lichen", "Properties": {"east": "true"}}},
-              {"weight": 1, "data": {"Name": "minecraft:glow_lichen", "Properties": {"west": "true"}}},
-              {"weight": 1, "data": {"Name": "minecraft:glow_lichen", "Properties": {"up": "true"}}},
-              {"weight": 1, "data": {"Name": "minecraft:glow_lichen", "Properties": {"down": "true"}}}
+              {"weight": 1, "data": {"Name": "minecraft:glow_lichen", "Properties": {"up": "true"}}}
             ]
           }
         },
@@ -28,6 +23,7 @@
             "type": "minecraft:matching_blocks",
             "blocks": "minecraft:blackstone"
           }
-        }
-      ]
-    }  }}
+        }      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- correct the glow_lichen patch so it only places lichen on top surfaces
- tidy closing braces and add trailing newline

## Testing
- `find 'DimDatapack v4' -name '*.json' -print0 | xargs -0 -I{} jq '.' {} >/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_686e91854fa4832a8dc6c21c5c34442e