### PR TITLE
Add noise settings for tundra desert dimension

### DIFF
--- a/DimDatapack v4/data/dd/dimension/tundra_desert.json
+++ b/DimDatapack v4/data/dd/dimension/tundra_desert.json
@@ -1,0 +1,16 @@
+{
+  "type": "dd:tundra_desert_type",
+  "generator": {
+    "type": "minecraft:noise",
+    "seed": 12345,
+    "settings": "dd:tundra_desert_noise",
+    "biome_source": {
+      "type": "minecraft:checkerboard",
+      "scale": 8,
+      "biomes": [
+        "dd:frozen_tundra",
+        "dd:arid_desert"
+      ]
+    }
+  }
+}

--- a/DimDatapack v4/data/dd/dimension_type/tundra_desert_type.json
+++ b/DimDatapack v4/data/dd/dimension_type/tundra_desert_type.json
@@ -1,0 +1,25 @@
+{
+  "ambient_light": 0.0,
+  "bed_works": true,
+  "coordinate_scale": 1.0,
+  "effects": "minecraft:overworld",
+  "has_ceiling": false,
+  "has_raids": true,
+  "has_skylight": true,
+  "height": 384,
+  "logical_height": 384,
+  "min_y": -64,
+  "infiniburn": "#minecraft:infiniburn_overworld",
+  "natural": true,
+  "piglin_safe": false,
+  "respawn_anchor_works": false,
+  "ultrawarm": false,
+  "monster_spawn_block_light_limit": 0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": {
+      "min_inclusive": 0,
+      "max_inclusive": 7
+    }
+  }
+}

--- a/DimDatapack v4/data/dd/worldgen/biome/arid_desert.json
+++ b/DimDatapack v4/data/dd/worldgen/biome/arid_desert.json
@@ -1,0 +1,36 @@
+{
+  "has_precipitation": false,
+  "temperature": 2.0,
+  "downfall": 0.0,
+  "effects": {
+    "fog_color": 12638463,
+    "sky_color": 16767104,
+    "water_color": 4159204,
+    "water_fog_color": 329011
+  },
+  "carvers": { "air": [], "liquid": [] },
+  "spawn_costs": {},
+  "spawners": {
+    "monster": [],
+    "creature": [],
+    "ambient": [],
+    "water_creature": [],
+    "water_ambient": [],
+    "misc": [],
+    "axolotls": [],
+    "underground_water_creature": []
+  },
+  "features": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ]
+}

--- a/DimDatapack v4/data/dd/worldgen/biome/frozen_tundra.json
+++ b/DimDatapack v4/data/dd/worldgen/biome/frozen_tundra.json
@@ -1,0 +1,36 @@
+{
+  "has_precipitation": true,
+  "temperature": 0.0,
+  "downfall": 0.5,
+  "effects": {
+    "fog_color": 12638463,
+    "sky_color": 12084889,
+    "water_color": 4159204,
+    "water_fog_color": 329011
+  },
+  "carvers": { "air": [], "liquid": [] },
+  "spawn_costs": {},
+  "spawners": {
+    "monster": [],
+    "creature": [],
+    "ambient": [],
+    "water_creature": [],
+    "water_ambient": [],
+    "misc": [],
+    "axolotls": [],
+    "underground_water_creature": []
+  },
+  "features": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ]
+}

--- a/DimDatapack v4/data/dd/worldgen/noise_settings/tundra_desert_noise.json
+++ b/DimDatapack v4/data/dd/worldgen/noise_settings/tundra_desert_noise.json
@@ -1,0 +1,165 @@
+{
+  "aquifers_enabled": true,
+  "default_block": {
+    "Name": "minecraft:stone"
+  },
+  "default_fluid": {
+    "Name": "minecraft:water",
+    "Properties": {
+      "level": "0"
+    }
+  },
+  "disable_mob_generation": false,
+  "legacy_random_source": false,
+  "noise": {
+    "height": 384,
+    "min_y": -64,
+    "size_horizontal": 1,
+    "size_vertical": 2
+  },
+  "noise_router": {
+    "barrier": 0.0,
+    "continents": 0.0,
+    "depth": 0.0,
+    "erosion": 0.0,
+    "final_density": {
+      "type": "minecraft:squeeze",
+      "argument": {
+        "type": "minecraft:mul",
+        "argument1": 0.64,
+        "argument2": {
+          "type": "minecraft:interpolated",
+          "argument": {
+            "type": "minecraft:blend_density",
+            "argument": {
+              "type": "minecraft:add",
+              "argument1": 2.5,
+              "argument2": {
+                "type": "minecraft:mul",
+                "argument1": {
+                  "type": "minecraft:y_clamped_gradient",
+                  "from_value": 0.0,
+                  "from_y": -72,
+                  "to_value": 1.0,
+                  "to_y": -40
+                },
+                "argument2": {
+                  "type": "minecraft:add",
+                  "argument1": -2.5,
+                  "argument2": {
+                    "type": "minecraft:add",
+                    "argument1": 0.9375,
+                    "argument2": {
+                      "type": "minecraft:mul",
+                      "argument1": {
+                        "type": "minecraft:y_clamped_gradient",
+                        "from_value": 1.0,
+                        "from_y": 104,
+                        "to_value": 0.0,
+                        "to_y": 128
+                      },
+                      "argument2": {
+                        "type": "minecraft:add",
+                        "argument1": -0.9375,
+                        "argument2": "minecraft:nether/base_3d_noise"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "fluid_level_floodedness": 0.0,
+    "fluid_level_spread": 0.0,
+    "initial_density_without_jaggedness": 0.0,
+    "lava": 0.0,
+    "ridges": 0.0,
+    "temperature": {
+      "type": "minecraft:shifted_noise",
+      "noise": "minecraft:temperature",
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0.0,
+      "shift_z": "minecraft:shift_z",
+      "xz_scale": 0.25,
+      "y_scale": 0.0
+    },
+    "vegetation": {
+      "type": "minecraft:shifted_noise",
+      "noise": "minecraft:vegetation",
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0.0,
+      "shift_z": "minecraft:shift_z",
+      "xz_scale": 0.25,
+      "y_scale": 0.0
+    },
+    "vein_gap": 0.0,
+    "vein_ridged": 0.0,
+    "vein_toggle": 0.0
+  },
+  "ore_veins_enabled": false,
+  "sea_level": 63,
+  "spawn_target": [],
+  "surface_rule": {
+    "type": "minecraft:sequence",
+    "sequence": [
+      {
+        "type": "minecraft:condition",
+        "if_true": {
+          "type": "minecraft:vertical_gradient",
+          "false_at_and_above": { "above_bottom": 5 },
+          "random_name": "minecraft:bedrock_floor",
+          "true_at_and_below": { "above_bottom": 0 }
+        },
+        "then_run": {
+          "type": "minecraft:block",
+          "result_state": { "Name": "minecraft:bedrock" }
+        }
+      },
+      {
+        "type": "minecraft:condition",
+        "if_true": {
+          "type": "minecraft:not",
+          "invert": {
+            "type": "minecraft:vertical_gradient",
+            "false_at_and_above": { "below_top": 0 },
+            "random_name": "minecraft:bedrock_roof",
+            "true_at_and_below": { "below_top": 5 }
+          }
+        },
+        "then_run": {
+          "type": "minecraft:block",
+          "result_state": { "Name": "minecraft:bedrock" }
+        }
+      },
+      {
+        "type": "minecraft:condition",
+        "if_true": {
+          "type": "minecraft:stone_depth",
+          "add_surface_depth": false,
+          "offset": 0,
+          "secondary_depth_range": 0,
+          "surface_type": "floor"
+        },
+        "then_run": {
+          "type": "minecraft:sequence",
+          "sequence": [
+            {
+              "type": "minecraft:condition",
+              "if_true": { "type": "minecraft:biome", "biome_is": ["dd:frozen_tundra"] },
+              "then_run": { "type": "minecraft:block", "result_state": { "Name": "minecraft:snow_block" } }
+            },
+            {
+              "type": "minecraft:condition",
+              "if_true": { "type": "minecraft:biome", "biome_is": ["dd:arid_desert"] },
+              "then_run": { "type": "minecraft:block", "result_state": { "Name": "minecraft:sand" } }
+            },
+            { "type": "minecraft:block", "result_state": { "Name": "minecraft:stone" } }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `tundra_desert_noise.json` with custom surface rules for frozen and arid biomes
- hook dimension `tundra_desert.json` to new noise settings

## Testing
- `python3 -m json.tool DimDatapack v4/data/dd/worldgen/noise_settings/tundra_desert_noise.json`
- `python3 -m json.tool DimDatapack v4/data/dd/dimension/tundra_desert.json`


------
https://chatgpt.com/codex/tasks/task_e_686ed0cd04f8832a863ca71be3dd7efa