### PR TITLE
Fix fairy_isles data for Minecraft 1.20

### DIFF
--- a/DimDatapack v4/data/dd/dimension_type/fairy_isles.json
+++ b/DimDatapack v4/data/dd/dimension_type/fairy_isles.json
@@ -12,6 +12,14 @@
   "min_y": -64,
   "height": 384,
   "logical_height": 384,
-  "infiniburn": "minecraft:infiniburn_overworld",
-  "effects": "dd:fairy_isles"
+  "infiniburn": "#minecraft:infiniburn_overworld",
+  "effects": "dd:fairy_isles",
+  "monster_spawn_block_light_limit": 0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": {
+      "min_inclusive": 0,
+      "max_inclusive": 7
+    }
+  }
 }

--- a/DimDatapack v4/data/dd/worldgen/biome/fairy_isles.json
+++ b/DimDatapack v4/data/dd/worldgen/biome/fairy_isles.json
@@ -1,8 +1,7 @@
 {
-  "precipitation": "none",
+  "has_precipitation": false,
   "temperature": 0.8,
   "downfall": 0.0,
-  "category": "none",
   "effects": {
     "sky_color": 13674751,
     "fog_color": 15256063,


### PR DESCRIPTION
## Summary
- update `fairy_isles` dimension type to include spawn light settings
- adjust infiniburn tag
- update biome format for 1.20

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f11d38644832abc7a5de94464b787