### PR TITLE
Fix world preset generator and add has_raids

### DIFF
--- a/DimDatapack v4/data/dd/dimension_type/fairy_isles.json
+++ b/DimDatapack v4/data/dd/dimension_type/fairy_isles.json
@@ -7,11 +7,12 @@
   "piglin_safe": false,
   "bed_works": true,
   "respawn_anchor_works": false,
+  "has_raids": false,
   "fixed_time": 6000,
   "ambient_light": 0.8,
   "min_y": -64,
   "height": 384,
   "logical_height": 384,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "effects": "dd:fairy_isles"
 }

--- a/DimDatapack v4/data/dd/worldgen/world_preset/multiverse.json
+++ b/DimDatapack v4/data/dd/worldgen/world_preset/multiverse.json
@@ -1,8 +1,26 @@
 {
   "dimensions": {
-    "minecraft:overworld": { "type": "minecraft:overworld" },
-    "minecraft:the_nether": { "type": "minecraft:the_nether" },
-    "minecraft:the_end":     { "type": "minecraft:the_end" },
+    "minecraft:overworld": {
+      "type": "minecraft:overworld",
+      "generator": {
+        "type": "minecraft:noise",
+        "settings": "minecraft:overworld"
+      }
+    },
+    "minecraft:the_nether": {
+      "type": "minecraft:the_nether",
+      "generator": {
+        "type": "minecraft:noise",
+        "settings": "minecraft:nether"
+      }
+    },
+    "minecraft:the_end": {
+      "type": "minecraft:the_end",
+      "generator": {
+        "type": "minecraft:noise",
+        "settings": "minecraft:end"
+      }
+    },
     "dd:fairy_isles": {
       "type": "dd:fairy_isles",
       "generator": {


### PR DESCRIPTION
## Summary
- add `has_raids` field to `fairy_isles` dimension type
- include full generators for vanilla dimensions in `multiverse` world preset

## Testing
- `jq empty 'DimDatapack v4/data/dd/dimension_type/fairy_isles.json'`
- `jq empty 'DimDatapack v4/data/dd/worldgen/world_preset/multiverse.json'`


------
https://chatgpt.com/codex/tasks/task_e_686f11d38644832abc7a5de94464b787