### PR TITLE
Update fairy_isles noise settings

### DIFF
--- a/DimDatapack v4/data/dd/worldgen/noise_settings/fairy_isles.json
+++ b/DimDatapack v4/data/dd/worldgen/noise_settings/fairy_isles.json
@@ -3,7 +3,7 @@
   "ore_veins_enabled": false,
   "disable_mob_generation": false,
   "legacy_random_source": false,
-  "default_block": { "Name": "minecraft:stone" },
+  "default_block": { "Name": "minecraft:purpur_block" },
   "default_fluid": { "Name": "minecraft:water", "Properties": { "level": "0" } },
   "sea_level": 0,
   "noise": {
@@ -54,22 +54,24 @@
     "sequence": [
       {
         "type": "minecraft:condition",
-        "if_true": {
-          "type": "minecraft:stone_depth",
-          "offset": 0,
-          "surface_type": "floor",
-          "add_surface_depth": false,
-          "secondary_depth_range": 0
-        },
+        "if_true": { "type": "minecraft:biome", "biome_is": [ "dd:fairy_isles" ] },
         "then_run": {
-          "type": "minecraft:block",
-          "result_state": { "Name": "minecraft:purple_terracotta" }
+          "type": "minecraft:sequence",
+          "sequence": [
+            {
+              "type": "minecraft:condition",
+              "if_true": { "type": "minecraft:stone_depth", "offset": 0, "add_surface_depth": true, "surface_type": "floor" },
+              "then_run": { "type": "minecraft:block", "result_state": { "Name": "minecraft:purple_terracotta" } }
+            },
+            {
+              "type": "minecraft:condition",
+              "if_true": { "type": "minecraft:stone_depth", "offset": 1, "add_surface_depth": true, "surface_type": "floor" },
+              "then_run": { "type": "minecraft:block", "result_state": { "Name": "minecraft:cyan_terracotta" } }
+            }
+          ]
         }
       },
-      {
-        "type": "minecraft:block",
-        "result_state": { "Name": "minecraft:cyan_terracotta" }
-      }
+      { "type": "minecraft:block", "result_state": { "Name": "minecraft:purpur_block" } }
     ]
   },
   "spawn_target": []


### PR DESCRIPTION
## Summary
- make fairy island blocks default to `purpur_block`
- tweak surface_rule to apply pastel terracotta layers for `dd:fairy_isles` biome with purpur fallback

## Testing
- `git diff --staged | head` *(checked patch before commit)*

------
https://chatgpt.com/codex/tasks/task_e_686fac9c2288832a8db09fd3ee9e9132